### PR TITLE
Add support for PostSampleAlternates

### DIFF
--- a/src/post.rs
+++ b/src/post.rs
@@ -49,11 +49,20 @@ pub struct PostPreview {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct PostSampleAlternates {
+    #[serde(rename = "type")]
+    pub stype: String,
+    pub height: u64,
+    pub width: u64,
+    pub urls: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct PostSample {
     pub width: u64,
     pub height: u64,
     pub url: Option<String>,
-    pub alternates: Option<HashMap<String, String>>,
+    pub alternates: Option<HashMap<String, PostSampleAlternates>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]

--- a/src/post.rs
+++ b/src/post.rs
@@ -53,7 +53,7 @@ pub struct PostSample {
     pub width: u64,
     pub height: u64,
     pub url: Option<String>,
-    pub alternatives: Option<HashMap<String, String>>,
+    pub alternates: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
@@ -182,7 +182,7 @@ impl PostSample {
             Width,
             Height,
             Url,
-            Alternatives
+            Alternates
         }
 
         struct PostSampleVisitor;
@@ -202,7 +202,7 @@ impl PostSample {
                 let mut width = None;
                 let mut height = None;
                 let mut url = None;
-                let mut alternatives = None;
+                let mut alternates = None;
 
                 while let Some(key) = map.next_key()? {
                     match key {
@@ -234,12 +234,12 @@ impl PostSample {
 
                             url = Some(map.next_value()?);
                         }
-                        Field::Alternatives => {
-                            if alternatives.is_some() {
-                                return Err(de::Error::duplicate_field("alternatives"));
+                        Field::Alternates => {
+                            if alternates.is_some() {
+                                return Err(de::Error::duplicate_field("alternates"));
                             }
 
-                            url = Some(map.next_value()?);
+                            alternates = Some(map.next_value()?);
                         }
                     }
                 }
@@ -252,12 +252,12 @@ impl PostSample {
                 if let Some(true) = has {
                     Ok(None)
                 } else {
-                    Ok(Some(PostSample { width, height, url, alternatives }))
+                    Ok(Some(PostSample { width, height, url, alternates }))
                 }
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["has", "width", "height", "url", "alternatives"];
+        const FIELDS: &'static [&'static str] = &["has", "width", "height", "url", "alternates"];
         de.deserialize_struct("PostSample", FIELDS, PostSampleVisitor)
     }
 }


### PR DESCRIPTION
## Reasoning
The API now has a field inside of `sample` called `alternates`. This field is usually empty, but is filled when there are different resolution sizes for a sample for videos. See post [2474986](https://e926.net/posts/2474986) for a rating:s sample. Additionally, with an update between when I first started this patch and now, they added it so every post now has this field (see post [39](https://e926.net/posts/39) for a rating: example of it being applied to an extremely old post).

## Solution
An extra struct (`PostSampleAlternates`) and an extra field (`alternates`) allow for proper handling of this.

Example usage:
```rust
let client = rs621::client::Client::new("https://e926.net", "rs621/0.6.0 (by zevaryx on e621)")?;
let mut post_stream = client.get_posts(&[2474986]);

while let Some(post) = post_stream.next().await {
    let tmp_post = post?;
    print!("Post #{}:", tmp_post.id);
    for key in tmp_post.sample.alternates.keys() {
        print!(" {}", key);
    }
    println!("");
}
```