### PR TITLE
Make a browser compatible rate limiter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ codecov = { repository = "nasso/rs621" }
 [features]
 default = ["rate-limit", "reqwest/default-tls"]
 socks = ["reqwest/socks"]
-rate-limit = ["tokio", "tokio/time", "tokio/sync"]
+rate-limit = ["gloo-timers", "futures", "web-time", "tokio"]
 
 [dependencies]
 thiserror = "1"
@@ -33,8 +33,15 @@ derivative = "2"
 itertools = "0.10"
 futures = { version = "0.3", default-features = false }
 reqwest = { version = ">=0.11, <0.13", default-features = false, features = ["json"] }
-tokio = { optional = true, version = "1" }
 
 [dev-dependencies]
 mockito = "0.30"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+gloo-timers = { optional = true, version = "0.3", features = ["futures"] }
+futures = { optional = true, version = "0.3", features = ["std", "alloc"] }
+web-time = { optional = true, version = "1.1.0" }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tokio = { optional = true, version = "1", features = ["time", "sync"] }

--- a/src/client/gloo_rate_limit.rs
+++ b/src/client/gloo_rate_limit.rs
@@ -1,0 +1,53 @@
+use super::REQ_COOLDOWN_DURATION;
+
+use futures::lock::{Mutex, MutexGuard};
+
+use std::future::Future;
+use std::sync::Arc;
+
+use web_time::Instant;
+
+#[derive(Debug, Clone, Default)]
+pub struct RateLimit {
+    // Use a `futures` `Mutex` because ~500ms is crazy long to block an async task.
+    deadline: Arc<Mutex<Option<Instant>>>,
+}
+
+struct Guard<'a>(MutexGuard<'a, Option<Instant>>);
+
+impl<'a> Drop for Guard<'a> {
+    fn drop(&mut self) {
+        // Use a `Drop` impl so that updating the deadline is panic-safe.
+        *self.0 = Some(Instant::now() + REQ_COOLDOWN_DURATION);
+    }
+}
+
+impl RateLimit {
+    async fn lock(&self) -> Guard {
+        loop {
+            let now = Instant::now();
+
+            let deadline = {
+                let guard = self.deadline.lock().await;
+
+                match &*guard {
+                    None => return Guard(guard),
+                    Some(deadline) if now >= *deadline => return Guard(guard),
+                    Some(deadline) => *deadline,
+                }
+            };
+
+            gloo_timers::future::sleep(deadline - now).await;
+        }
+    }
+
+    pub async fn check<F, R>(self, fut: F) -> R
+    where
+        F: Future<Output = R>,
+    {
+        let guard = self.lock().await;
+        let result = fut.await;
+        drop(guard);
+        result
+    }
+}

--- a/src/client/tokio_rate_limit.rs
+++ b/src/client/tokio_rate_limit.rs
@@ -1,13 +1,11 @@
-use futures::Future;
+use super::REQ_COOLDOWN_DURATION;
+
+use std::future::Future;
 
 use std::sync::Arc;
 
 use tokio::sync::{Mutex, MutexGuard};
-use tokio::time::{sleep_until, Duration, Instant};
-
-/// Forced cool down duration performed at every request. E621 allows at most 2 requests per second,
-/// so the lowest safe value we can have here is 500 ms.
-const REQ_COOLDOWN_DURATION: Duration = Duration::from_millis(600);
+use tokio::time::{sleep_until, Instant};
 
 #[derive(Debug, Clone, Default)]
 pub struct RateLimit {


### PR DESCRIPTION
Noticed I was hitting the rate limit in my web app, so here's an implementation of the rate limiter that works in the browser.

It's in its own crate to keep the dependency tree manageable. If the `rate-limit` feature is not enabled, no additional dependencies are compiled. On the other hand, if it is enabled, only the platform specific dependencies are compiled. I'm not sure there's a way to mix `target.'cfg(...)'.dependencies` and features otherwise.

Further investigation is needed to know if the `OPTIONS` + `POST` request pattern required by CORS counts as two API requests.